### PR TITLE
Add RuntimeDirectory to service file

### DIFF
--- a/debian/redis-server.service
+++ b/debian/redis-server.service
@@ -12,6 +12,7 @@ Restart=always
 User=redis
 Group=redis
 
+RuntimeDirectory=redis
 ExecStartPre=-/bin/run-parts --verbose /etc/redis/redis-server.pre-up.d
 ExecStartPost=-/bin/run-parts --verbose /etc/redis/redis-server.post-up.d
 ExecStop=-/bin/run-parts --verbose /etc/redis/redis-server.pre-down.d


### PR DESCRIPTION
* Since the pid file is being created under /var/run/redis/, if that directory doesn't exist, the service will refuse to start:

```
Nov 30 13:29:04 debian-redis-test systemd[1]: PID file
/var/run/redis/redis-server.pid not readable (yet?) after start-post
```
* The RuntimeDirectory is exactly for this usecase, from the docs:

> System daemons frequently require private runtime directories below /run to place communication sockets and similar in. For these, consider declaring them in their unit files using RuntimeDirectory= (see systemd.exec(5) for details), if this is feasible.
