### PR TITLE
Minor bugfix : Typographical error in redis-server and redis-sentinel systemd unit file

### DIFF
--- a/debian/redis-sentinel.service
+++ b/debian/redis-sentinel.service
@@ -11,7 +11,7 @@ TimeoutStopSec=0
 Restart=always
 User=redis
 Group=redis
-RunTimeDirectory=redis
+RuntimeDirectory=redis
 
 ExecStartPre=-/bin/run-parts --verbose /etc/redis/redis-sentinel.pre-up.d
 ExecStartPost=-/bin/run-parts --verbose /etc/redis/redis-sentinel.post-up.d

--- a/debian/redis-server.service
+++ b/debian/redis-server.service
@@ -11,7 +11,7 @@ TimeoutStopSec=0
 Restart=always
 User=redis
 Group=redis
-RunTimeDirectory=redis
+RuntimeDirectory=redis
 
 ExecStartPre=-/bin/run-parts --verbose /etc/redis/redis-server.pre-up.d
 ExecStartPost=-/bin/run-parts --verbose /etc/redis/redis-server.post-up.d


### PR DESCRIPTION
The latest packages : 

- `redis-server/jessie,now 2:3.2.8-1~dotdeb+8.1`
- `redis-sentinel/jessie 2:3.2.8-1~dotdeb+8.1`

both have a typographical error in their systemd unit file.

The directive `RuntimeDirectory` is misspelled as `RuntimeDirectory` which results in the following error : 
```
Mar 17 13:47:19  systemd[1]: [/lib/systemd/system/redis-server.service:14] Unknown lvalue 'RunTimeDirectory' in section 'Service'
```

The bug was fixed in the debian maintained packaged in january : https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850534

Regards,

Leo